### PR TITLE
Also include datasets dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "flair",
     "seqeval",
     "tqdm",
+    "datasets",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
`GLiREL` use in a `spaCy` pipeline requires the `datasets` library dependency be included in the `pyproject.toml` project file.